### PR TITLE
build(ci): 升级 upload-artifact 动作到 v4版本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: maven-artifacts-${{ env.RELEASE_VERSION }}
         path: |


### PR DESCRIPTION
- 将 GitHub Actions 的 upload-artifact 动作从 v3 升级到 v4
- 此升级可能会提高构建工件上传的效率和可靠性