### PR TITLE
chore(build): 更新 Maven 编译器插件版本并升级 Java 版本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '21'
         distribution: 'temurin'
         server-id: oss
         server-username: MAVEN_USERNAME

--- a/structure-dependencies/pom.xml
+++ b/structure-dependencies/pom.xml
@@ -69,7 +69,7 @@
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
         <maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
         <maven-compiler-plugin>3.8.1</maven-compiler-plugin>
-        <maven-compiler-plugin.version>2.5</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.5</maven-surefire-plugin.version>
         <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
@@ -509,6 +509,7 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <!-- Javadoc -->


### PR DESCRIPTION
- 将 maven-compiler-plugin 版本从 2.5 升级到 3.8.1
- 在编译器配置中添加 release 参数以支持模块化编译
- 将 GitHub Actions 工作流中的 Java 版本从 8 升级到 21