### PR TITLE
chore(pom): 完善项目元数据配置并添加flatten插件

### DIFF
--- a/structure-rpc-starter/pom.xml
+++ b/structure-rpc-starter/pom.xml
@@ -16,11 +16,40 @@
     <artifactId>structure-rpc-starter</artifactId>
     <description>这个是一个远程服务调用的实现</description>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+    <url>https://projects.structured.cn/structure-boot</url>
+    <inceptionYear>2021</inceptionYear>
+    <organization>
+        <name>structure</name>
+    </organization>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>chuckLcq</id>
+            <name>chuck</name>
+            <email>15524415221@163.com</email>
+        </developer>
+        <developer>
+            <id>lchqJava</id>
+            <name>Chuanqiang Liu</name>
+            <email>361648887@qq.com</email>
+        </developer>
+    </developers>
+
+    <issueManagement>
+        <system>Github</system>
+        <url>https://github.com/structure-projects/structure-boot/issues</url>
+    </issueManagement>
+
+    <scm>
+        <url>https://github.com/structure-projects/structure-boot</url>
+        <connection>scm:git:git://github.com/structure-projects/structure-boot.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:structure-projects/structure-boot.git</developerConnection>
+    </scm>
 
     <dependencies>
         <dependency>
@@ -46,4 +75,35 @@
         </dependency>
 
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${maven-flatten-maven-plugin.version}</version>
+                <configuration>
+                    <flattenedPomFilename>pom-xml-flattened</flattenedPomFilename>
+                    <updatePomFile>true</updatePomFile>
+                    <!-- 使用 oss 模式适合发布到 Maven 中央仓库的 jar 包 -->
+                    <flattenMode>oss</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
- 添加项目URL、成立年份、组织信息
- 配置Apache License许可证信息
- 添加开发者信息包括chuckLcq和lchqJava
- 配置问题管理系统和SCM版本控制信息
- 添加flatten-maven-plugin插件用于依赖扁平化处理
- 配置插件执行阶段和目标用于资源处理和清理